### PR TITLE
CoroutineRedisConnector: fixed defer state

### DIFF
--- a/src/Connectors/CoroutineRedisConnector.php
+++ b/src/Connectors/CoroutineRedisConnector.php
@@ -41,7 +41,9 @@ class CoroutineRedisConnector implements ConnectorInterface
     {
         /**@var Redis $connection */
         if (isset($config['database'])) {
+            $connection->setDefer(true);
             $connection->select($config['database']);
+            $connection->recv();
         }
         $connection->setDefer(false);
     }


### PR DESCRIPTION
When selecting a Redis database on connection start, `$connection->recv();` should be called to "finish" the select query and prevent returning "true" (or "1") from select query in application business logic